### PR TITLE
Add skew example configs

### DIFF
--- a/examples/config-reload-with-skew.yaml
+++ b/examples/config-reload-with-skew.yaml
@@ -1,0 +1,17 @@
+# for this test, start with this config, then wait to be sure the
+# targets from .fetchit/config.yaml are populated
+# and for follow-up test, push a change to the config and confirm
+# new targets are fetched & run
+targets:
+- name: fetchit
+  url: https://github.com/redhat-et/fetchit
+  methods:
+    configTarget:
+      configUrl: https://raw.githubusercontent.com/redhat-et/fetchit/main/examples/config-reload-with-skew.yaml
+      schedule: "*/2 * * * *"
+    raw:
+      targetPath: examples/raw
+      schedule: "*/1 * * * *"
+      pullImage: true
+      skew: 5000
+  branch: main

--- a/examples/config-url-with-skew.yaml
+++ b/examples/config-url-with-skew.yaml
@@ -1,0 +1,10 @@
+# This is an example configTarget that is used in testing. fetchit will start with this config then will load targets from ./examples/config-reload.yaml
+# Note: It takes (default) 5 min for raw urls to be updated in GitHub, so this test will wait for 7 min
+targets:
+- name: fetchit
+  url: http://github.com/redhat-et/fetchit
+  methods:
+    configTarget:
+      configUrl: https://raw.githubusercontent.com/redhat-et/fetchit/main/examples/config-reload-with-skew.yaml
+      schedule: "*/1 * * * *"
+

--- a/examples/full-suite-with-skew.yaml
+++ b/examples/full-suite-with-skew.yaml
@@ -1,0 +1,25 @@
+volume: fetchit-volume # this needs to match the volume name passed to the podman run command
+targets:
+- name: fetchit
+  url: http://github.com/redhat-et/fetchit
+  methods:
+    raw:
+      targetPath: examples/raw
+      schedule: "*/1 * * * *"
+      skew: 10000
+    systemd:
+      targetPath: examples/systemd/httpd.service
+      root: true
+      enable: false
+      schedule: "*/1 * * * *"
+      skew: 1000
+    ansible:
+      targetPath: examples/ansible
+      sshDirectory: /root/.ssh
+      schedule: "*/1 * * * *"
+    filetransfer:
+      targetPath: examples/filetransfer
+      destinationDirectory: /tmp/ft
+      schedule: "*/1 * * * *"
+      skew: 3000
+  branch: main


### PR DESCRIPTION
This commit adds the example configs to use
the skew feature where on users can specify
the length of the window of time they want
harpoon to distribute runs of each method over
in milliseconds.

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>