### PR TITLE
update unit files and run cmds with --security-opt

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -155,7 +155,7 @@ jobs:
         run: sudo mkdir /root/.fetchit
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v /root/.fetchit:/opt/mount -e FETCHIT_CONFIG_URL=https://raw.githubusercontent.com/redhat-et/fetchit/main/examples/raw-config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v /root/.fetchit:/opt/mount -e FETCHIT_CONFIG_URL=https://raw.githubusercontent.com/redhat-et/fetchit/main/examples/raw-config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
 
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -194,7 +194,7 @@ jobs:
         run: sudo mkdir /root/.fetchit && sudo cp ./examples/config-url.yaml /root/.fetchit/config.yaml
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v /root/.fetchit/config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v /root/.fetchit/config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
         
       - name: Wait for fetchit to deploy
         run: sleep 7m
@@ -233,7 +233,7 @@ jobs:
         run: sudo mkdir /root/.fetchit && sudo cp ./examples/config-url-with-skew.yaml /root/.fetchit/config.yaml
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v /root/.fetchit/config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v /root/.fetchit/config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
         
       - name: Wait for fetchit to deploy
         run: sleep 7m
@@ -269,7 +269,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
         
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v ./examples/raw-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v ./examples/raw-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
         
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -305,7 +305,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
         
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v ./examples/default-volume.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v ./examples/default-volume.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
         
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -347,7 +347,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/filetransfer-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/filetransfer-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
 
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -386,7 +386,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/filetransfer-config-single-file.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/filetransfer-config-single-file.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
 
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -422,7 +422,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
         
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -476,7 +476,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-systemd-amd:latest quay.io/fetchit/fetchit-systemd:latest
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-autoupdate.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-autoupdate.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
 
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -533,7 +533,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-systemd-amd:latest quay.io/fetchit/fetchit-systemd:latest
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-enable.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-enable.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
 
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -589,7 +589,7 @@ jobs:
         run: podman tag quay.io/fetchit/fetchit-systemd-amd:latest quay.io/fetchit/fetchit-systemd:latest
 
       - name: Start fetchit
-        run: podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-enable-user.yaml:/opt/mount/config.yaml -v /run/user/"${UID}"/podman/podman.sock:/run/podman/podman.sock -e XDG_RUNTIME_DIR="/run/user/${UID}" -e HOME="${HOME}" quay.io/fetchit/fetchit-amd:latest
+        run: podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-enable-user.yaml:/opt/mount/config.yaml -v /run/user/"${UID}"/podman/podman.sock:/run/podman/podman.sock -e XDG_RUNTIME_DIR="/run/user/${UID}" -e HOME="${HOME}" --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
 
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -640,7 +640,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-systemd-amd:latest quay.io/fetchit/fetchit-systemd:latest
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-restart.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-restart.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
 
       - name: Wait for fetchit to deploy
         run: sleep 4m
@@ -697,7 +697,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
         
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/ansible.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/ansible.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
 
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -730,7 +730,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-config-single-file.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/systemd-config-single-file.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
  
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -766,7 +766,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
         
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v ./examples/kube-play-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v ./examples/kube-play-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
         
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -802,7 +802,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
         
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v ./examples/clean-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v ./examples/clean-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
         
       - name: Wait for fetchit to deploy
         run: sleep 2m
@@ -852,7 +852,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
   
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/full-suite.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/full-suite.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
         
       - name: Wait for fetchit to deploy
         run: sleep 150s
@@ -897,7 +897,7 @@ jobs:
         run: sudo podman tag quay.io/fetchit/fetchit-amd:latest quay.io/fetchit/fetchit:latest
   
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/full-suite-with-skew.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v ./examples/full-suite-with-skew.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
         
       - name: Wait for fetchit to deploy
         run: sleep 150s
@@ -967,7 +967,7 @@ jobs:
           sed -i 's|   branch: ci|  branch: "{{ github.ref }}"|g' /home/runner/work/fetchit/fetchit/main/examples/ci-config.yaml
 
       - name: Start fetchit
-        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v /home/runner/work/fetchit/fetchit/main/examples/ci-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit-amd:latest
+        run: sudo podman run -d --name fetchit -v fetchit-volume:/opt -v /home/runner/work/fetchit/fetchit/main/examples/ci-config.yaml:/opt/mount/config.yaml -v /run/podman/podman.sock:/run/podman/podman.sock --security-opt label=disable quay.io/fetchit/fetchit-amd:latest
 
       - name: Wait for fetchit to deploy
         run: sleep 2m

--- a/README.md
+++ b/README.md
@@ -55,32 +55,27 @@ Two systemd files are provided to allow for FetchIt to run as a user or as root.
 
 Ensure that there is a config at `$HOME/.fetchit/config.yaml` before attempting to start the service.
 
-NOTE: SELinux is temporarily disabled until the work to define the specific SELinux rules are completed.
-
 For root
 ```
-setenforce 0
 cp systemd/fetchit.root /etc/systemd/system/fetchit.service
 systemctl enable fetchit --now
 ```
 
-
-NOTE: SELinux is temporarily disabled until the work to define the specific SELinux rules are completed.
-
 ```
 mkdir -p ~/.config/systemd/user/
-setenforce 0
 cp systemd/fetchit.user ~/.config/systemd/user/
 systemctl --user enable fetchit --now
 ```
 
 #### Manually launch the fetchit container using a podman volume
 
-NOTE: SELinux is temporarily disabled until the work to define the specific SELinux rules are completed.
-
 ```
-setenforce 0
-podman run -d --rm --name fetchit -v fetchit-volume:/opt -v $HOME/.fetchit:/opt/mount -v /run/user/$(id -u)/podman//podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit:latest
+podman run -d --rm --name fetchit \
+    -v fetchit-volume:/opt \
+    -v $HOME/.fetchit:/opt/mount \
+    -v /run/user/$(id -u)/podman//podman.sock:/run/podman/podman.sock \
+    --security-opt label=disable \
+    quay.io/fetchit/fetchit:latest
 ```
 
 **NOTE:**

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -36,24 +36,18 @@ The two systemd files are differentiated by .root and .user.
 
 Ensure that the location of the `config.yaml` is correctly defined in the systemd service file before attempting to start the service.
 
-NOTE: SELinux is temporarily disabled until the work to define the specific SELinux rules are completed.
-
 For root
 
 .. code-block:: bash
    
-   sudo setenforce 0
    cp systemd/fetchit.root /etc/systemd/system/fetchit.service
    systemctl enable fetchit --now
 
 
 For user ensure that the path for the configuration file `/home/fetchiter/config.yaml:/opt/config.yaml` and the path for the podman socket are correct.
 
-NOTE: SELinux is temporarily disabled until the work to define the specific SELinux rules are completed.
-
 .. code-block:: bash
    
-   sudo setenforce 0
    mkdir -p ~/.config/systemd/user/
    cp systemd/fetchit.user ~/.config/systemd/user/
    systemctl --user enable fetchit --now
@@ -63,8 +57,12 @@ Manually
 
 .. code-block:: bash
    
-   sudo setenforce 0
-   podman run -d --name fetchit -v fetchit-volume:/opt -v ./config.yaml:/opt/config.yaml -v /run/user/1000/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit:latest
+   podman run -d --name fetchit \
+     -v fetchit-volume:/opt \
+     -v ./config.yaml:/opt/config.yaml \
+     -v /run/user/1000/podman/podman.sock:/run/podman/podman.sock \
+     --security-opt label=disable \
+     quay.io/fetchit/fetchit:latest
 
 FetchIt will clone the repository and attempt to remediate those items defined in the config.yaml file. To follow the status.
 

--- a/systemd/fetchit-root.service
+++ b/systemd/fetchit-root.service
@@ -11,7 +11,7 @@ Restart=always
 TimeoutStopSec=65
 ExecStartPre=/usr/bin/mkdir -p %h/.fetchit
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon --replace --label io.containers.autoupdate=registry -d --name fetchit -v fetchit-volume:/opt -v %h/.fetchit:/opt/mount -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit:latest
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --security-opt label=disable --sdnotify=conmon --replace --label io.containers.autoupdate=registry -d --name fetchit -v fetchit-volume:/opt -v %h/.fetchit:/opt/mount -v /run/podman/podman.sock:/run/podman/podman.sock quay.io/fetchit/fetchit:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify

--- a/systemd/fetchit-user.service
+++ b/systemd/fetchit-user.service
@@ -11,7 +11,7 @@ Restart=always
 TimeoutStopSec=65
 ExecStartPre=/usr/bin/mkdir -p %h/.fetchit
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon --replace --label io.containers.autoupdate=registry -d --name fetchit -v fetchit-volume:/opt -v %h/.fetchit:/opt/mount -v /run/user/%U/podman/podman.sock:/run/podman/podman.sock -e XDG_RUNTIME_DIR="/run/user/%U" -e HOME=%h quay.io/fetchit/fetchit:latest
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --security-opt label=disable --sdnotify=conmon --replace --label io.containers.autoupdate=registry -d --name fetchit -v fetchit-volume:/opt -v %h/.fetchit:/opt/mount -v /run/user/%U/podman/podman.sock:/run/podman/podman.sock -e XDG_RUNTIME_DIR="/run/user/%U" -e HOME=%h quay.io/fetchit/fetchit:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify


### PR DESCRIPTION
@cooktheryan @josephsawaya 
This PR
* removes the `disable SELinux, setenforce 0` instructions
* adds `security-opt label=disable` to workflow podman run cmds and the fetchit unit files
* renames harpoon-*.service to fetchit.*service

thanks to @rhatdan for keeping us honest 